### PR TITLE
Bug in api gen with regex

### DIFF
--- a/kube_codegen.sh
+++ b/kube_codegen.sh
@@ -33,7 +33,7 @@ function kube::codegen::internal::git_find() {
 function kube::codegen::internal::git_grep() {
     # We want to include modified and untracked files because this might be
     # running against code which is not tracked by git yet.
-    git grep --untracked "$@" ":(exclude)vendor/"
+    git grep --untracked "$@" ":(exclude)*vendor/"
 }
 
 # Generate tagged helper code: conversions, deepcopy, and defaults


### PR DESCRIPTION
Before:

```
git grep --untracked -l -e +genclient ':(glob)/private/tmp/hypershift/api/**/*.go' ':(exclude)vendor/'
api/certificates/v1alpha1/certificatesigningrequestapproval_types.go
api/hypershift/v1alpha1/hostedcluster_types.go
api/hypershift/v1alpha1/nodepool_types.go
api/hypershift/v1beta1/certificatesigningrequestapproval_types.go
api/hypershift/v1beta1/hosted_controlplane.go
api/hypershift/v1beta1/hostedcluster_types.go
api/hypershift/v1beta1/nodepool_types.go
api/vendor/github.com/openshift/api/config/v1/types_apiserver.go
api/vendor/github.com/openshift/api/config/v1/types_authentication.go
api/vendor/github.com/openshift/api/config/v1/types_build.go
api/vendor/github.com/openshift/api/config/v1/types_cluster_operator.go
api/vendor/github.com/openshift/api/config/v1/types_cluster_version.go
api/vendor/github.com/openshift/api/config/v1/types_console.go
api/vendor/github.com/openshift/api/config/v1/types_dns.go
api/vendor/github.com/openshift/api/config/v1/types_feature.go
api/vendor/github.com/openshift/api/config/v1/types_image.go
api/vendor/github.com/openshift/api/config/v1/types_image_content_policy.go
api/vendor/github.com/openshift/api/config/v1/types_image_digest_mirror_set.go
api/vendor/github.com/openshift/api/config/v1/types_image_tag_mirror_set.go
api/vendor/github.com/openshift/api/config/v1/types_infrastructure.go
api/vendor/github.com/openshift/api/config/v1/types_ingress.go
api/vendor/github.com/openshift/api/config/v1/types_network.go
api/vendor/github.com/openshift/api/config/v1/types_node.go
api/vendor/github.com/openshift/api/config/v1/types_oauth.go
api/vendor/github.com/openshift/api/config/v1/types_operatorhub.go
api/vendor/github.com/openshift/api/config/v1/types_project.go
api/vendor/github.com/openshift/api/config/v1/types_proxy.go
api/vendor/github.com/openshift/api/config/v1/types_scheduling.go
api/vendor/k8s.io/api/core/v1/types.go
```

After:

```
git grep --untracked -l -e +genclient ':(glob)/private/tmp/hypershift/api/**/*.go' ':(exclude)*vendor/'
api/certificates/v1alpha1/certificatesigningrequestapproval_types.go
api/hypershift/v1alpha1/hostedcluster_types.go
api/hypershift/v1alpha1/nodepool_types.go
api/hypershift/v1beta1/certificatesigningrequestapproval_types.go
api/hypershift/v1beta1/hosted_controlplane.go
api/hypershift/v1beta1/hostedcluster_types.go
api/hypershift/v1beta1/nodepool_types.go
```